### PR TITLE
Relocatable rpm

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,7 @@
+repositories {
+    jcenter()
+}
+
+dependencies {
+    compile 'org.redline-rpm:redline:1.2.7'
+}

--- a/buildSrc/src/main/groovy/org/rundeck/gradle/PackagingTask.groovy
+++ b/buildSrc/src/main/groovy/org/rundeck/gradle/PackagingTask.groovy
@@ -7,6 +7,8 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.api.Task
 import org.gradle.api.tasks.*
 
+import org.redline_rpm.header.Flags
+
 class PackageTask extends DefaultTask {
 
     @Input
@@ -229,6 +231,8 @@ class PackageTask extends DefaultTask {
             // Install scripts
             postInstall project.file("$libDir/deb/scripts/postinst")
             if (packageName =~ /enterprise/) {
+                replaces('rundeckpro-cluster', '3.0.9', Flags.LESS | Flags.EQUAL)
+                conflicts('rundeckpro-cluster', '3.0.9', Flags.LESS | Flags.EQUAL)
                 postInstall project.file("$libDir/deb/scripts/postinst-cluster")
             }
             preUninstall "service rundeckd stop"
@@ -263,6 +267,7 @@ class PackageTask extends DefaultTask {
             preInstall project.file("$libDir/rpm/scripts/preinst.sh")
             postInstall project.file("$libDir/rpm/scripts/postinst.sh")
             if (packageName =~ /enterprise/) {
+                obsoletes('rundeckpro-cluster', '3.0.9', Flags.EQUAL | Flags.LESS)
                 postInstall project.file("$libDir/rpm/scripts/postinst-cluster.sh")
             }
             preUninstall project.file("$libDir/rpm/scripts/preuninst.sh")

--- a/buildSrc/src/main/groovy/org/rundeck/gradle/PackagingTask.groovy
+++ b/buildSrc/src/main/groovy/org/rundeck/gradle/PackagingTask.groovy
@@ -86,50 +86,58 @@ class PackageTask extends DefaultTask {
             signingKeyRingFile = project.findProperty('signingKeyRingFile')
 
             // Create Dirs
-            directory("/etc/rundeck", 0750)
-            directory("/var/log/rundeck", 0775)
-            directory("/var/lib/rundeck", 0755)
-            directory("/var/lib/rundeck/.ssh", 0700)
-            directory("/var/lib/rundeck/bootstrap", 0755)
-            directory("/var/lib/rundeck/cli", 0755)
-            directory("/var/lib/rundeck/cli/lib", 0755)
-            directory("/var/lib/rundeck/cli/bin", 0755)
-            directory("/var/lib/rundeck/logs", 0755)
-            directory("/var/lib/rundeck/data", 0755)
-            directory("/var/lib/rundeck/work", 0755)
-            directory("/var/lib/rundeck/libext", 0755)
-            directory("/var/lib/rundeck/var", 0755)
-            directory("/var/lib/rundeck/var/tmp", 0755)
-            directory("/var/lib/rundeck/var/tmp/pluginJars", 0755)
-            directory("/var/rundeck", 0755)
-            directory("/var/rundeck/projects", 0755)
-            directory("/tmp/rundeck", 1755)
-            directory("/var/lib/rundeck/libext", 0755)
+            directory("/etc/rundeck", 0750, 'rundeck', 'rundeck')
+            directory("/var/log/rundeck", 0775, 'rundeck', 'rundeck')
+            directory("/var/lib/rundeck", 0755, 'rundeck', 'rundeck')
+            directory("/var/lib/rundeck/.ssh", 0700, 'rundeck', 'rundeck')
+            directory("/var/lib/rundeck/bootstrap", 0755, 'rundeck', 'rundeck')
+            directory("/var/lib/rundeck/cli", 0755, 'rundeck', 'rundeck')
+            directory("/var/lib/rundeck/cli/lib", 0755, 'rundeck', 'rundeck')
+            directory("/var/lib/rundeck/cli/bin", 0755, 'rundeck', 'rundeck')
+            directory("/var/lib/rundeck/logs", 0755, 'rundeck', 'rundeck')
+            directory("/var/lib/rundeck/data", 0755, 'rundeck', 'rundeck')
+            directory("/var/lib/rundeck/work", 0755, 'rundeck', 'rundeck')
+            directory("/var/lib/rundeck/libext", 0755, 'rundeck', 'rundeck')
+            directory("/var/lib/rundeck/var", 0755, 'rundeck', 'rundeck')
+            directory("/var/lib/rundeck/var/tmp", 0755, 'rundeck', 'rundeck')
+            directory("/var/lib/rundeck/var/tmp/pluginJars", 0755, 'rundeck', 'rundeck')
+            directory("/tmp/rundeck", 1755, 'rundeck', 'rundeck')
+            directory("/var/lib/rundeck/libext", 0755, 'rundeck', 'rundeck')
 
             from("$libDir/common/etc/rundeck") {
+                into "${rdConfDir}"
+                user 'rundeck'
+                permissionGroup 'rundeck'
                 fileType it.CONFIG | it.NOREPLACE
                 fileMode 0640
-                into "${rdConfDir}"
             }
 
             from("artifacts") {
-                include "${artifact.name}"
                 into "${rdBaseDir}/bootstrap"
+                user 'rundeck'
+                permissionGroup 'rundeck'
+                include "${artifact.name}"
             }
 
             from("$warContentDir/WEB-INF/rundeck/plugins") {
+                into "${rdBaseDir}/libext"
+                user 'rundeck'
+                permissionGroup 'rundeck'
                 include "*.jar"
                 include "*.zip"
                 include "*.groovy"
-                into "${rdBaseDir}/libext"
             }
 
             from("$cliContentDir/bin") {
                 into "$rdBaseDir/cli/bin"
+                user 'rundeck'
+                permissionGroup 'rundeck'
             }
 
             from("$cliContentDir/lib") {
                 into "$rdBaseDir/cli/lib"
+                user 'rundeck'
+                permissionGroup 'rundeck'
             }
             def tools = new File(cliContentDir, "bin").listFiles()*.name
 
@@ -229,13 +237,20 @@ class PackageTask extends DefaultTask {
             // Copy Files
 
             from("$libDir/deb/etc") {
-                fileType CONFIG | NOREPLACE
                 into "/etc"
+                fileType CONFIG | NOREPLACE
             }
         }
 
         def rpmBuild = project.task("build-$packageName-rpm", type: project.Rpm, group: 'build') {
             dependsOn prepareTask
+
+            prefix('/var/lib/rundeck')
+            prefix('/etc/rundeck')
+            prefix('/usr/bin')
+            prefix('/var/log/rundeck')
+            prefix('/etc/rc.d/init.d')
+            prefix('/tmp/rundeck')
 
             applySharedConfig(it)
 
@@ -255,16 +270,18 @@ class PackageTask extends DefaultTask {
 
             // Copy Files
             from("$libDir/rpm/etc/rc.d/init.d/rundeckd") {
-                fileMode 0755
+                into "/etc/rc.d/init.d"
                 user = "root"
                 permissionGroup = "root"
-                into "/etc/rc.d/init.d"
+                fileMode 0755
             }
 
             from("$libDir/rpm/etc/rundeck") {
+                into "${rdConfDir}"
+                user 'rundeck'
+                permissionGroup 'rundeck'
                 fileType CONFIG | NOREPLACE
                 fileMode 0640
-                into "${rdConfDir}"
             }
         }
 

--- a/lib/common/etc/rundeck/framework.properties
+++ b/lib/common/etc/rundeck/framework.properties
@@ -16,7 +16,7 @@ framework.server.url = http://localhost:4440
 
 rdeck.base=/var/lib/rundeck
 
-framework.projects.dir=/var/rundeck/projects
+framework.projects.dir=/var/lib/rundeck/projects
 framework.etc.dir=/etc/rundeck
 framework.var.dir=/var/lib/rundeck/var
 framework.tmp.dir=/var/lib/rundeck/var/tmp

--- a/lib/common/etc/rundeck/project.properties
+++ b/lib/common/etc/rundeck/project.properties
@@ -6,16 +6,16 @@
 #
 # The base directory for this project's instances
 #
-project.dir = /var/rundeck/projects/${project.name}
+project.dir = /var/lib/rundeck/projects/${project.name}
 #
 # The base directory of project specific configuration files
 #
-project.etc.dir = /var/rundeck/projects/${project.name}/etc
+project.etc.dir = /var/lib/rundeck/projects/${project.name}/etc
 
 #
 # The resources registration file
 #
-project.resources.file = /var/rundeck/projects/${project.name}/etc/resources.xml
+project.resources.file = /var/lib/rundeck/projects/${project.name}/etc/resources.xml
 
 #
 # The project description

--- a/lib/deb/scripts/postinst
+++ b/lib/deb/scripts/postinst
@@ -68,11 +68,8 @@ setperm rundeck rundeck 0750 /var/lib/rundeck/var
 setperm rundeck rundeck 0750 /var/lib/rundeck/var/tmp
 setperm rundeck rundeck 0750 /var/lib/rundeck/var/tmp/pluginJars
 setperm rundeck rundeck 0700 /var/lib/rundeck/.ssh
-setperm rundeck rundeck 0750 /var/rundeck
-setperm rundeck rundeck 0750 /var/rundeck/projects
 setperm rundeck adm 2751 /var/log/rundeck
 setperm rundeck rundeck 0750 /var/lib/rundeck/bootstrap
-#    setperm rundeck rundeck 0750 /var/lib/rundeck/cli
 setperm rundeck rundeck 0750 /var/lib/rundeck/libext
 setperm rundeck rundeck 0750 /tmp/rundeck
 setperm rundeck rundeck 0750 /etc/rundeck

--- a/lib/rpm/scripts/postinst-cluster.sh
+++ b/lib/rpm/scripts/postinst-cluster.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-DIR=/etc/rundeck
+DIR="${RPM_INSTALL_PREFIX1:-/etc/rundeck}"
+
 RDECK_CONFIG="$DIR/rundeck-config.properties"
 
 if [ -f "$DIR/rundeck-config.properties.rpmnew" ]; then

--- a/lib/rpm/scripts/postinst.sh
+++ b/lib/rpm/scripts/postinst.sh
@@ -1,17 +1,24 @@
 #!/bin/sh
 
-#Set owner on dirs
-chown -R rundeck:rundeck /var/lib/rundeck /var/rundeck /etc/rundeck /var/log/rundeck /tmp/rundeck
+HOME_DIR="${RPM_INSTALL_PREFIX0:-/var/lib/rundeck}"
+ETC_DIR="${RPM_INSTALL_PREFIX1:-/etc/rundeck}"
+BIN_DIR="${RPM_INSTALL_PREFIX2:-/usr/bin}"
+LOG_DIR="${RPM_INSTALL_PREFIX3:-/var/log/rundeck}"
+INIT_DIR="${RPM_INSTALL_PREFIX4:-/etc/rc.d/init.d}"
+TMP_DIR="${RPM_INSTALL_PREFIX5:-/tmp/rundeck}"
 
 if [ ! -e ~rundeck/.ssh/id_rsa ]; then
 	su -c "ssh-keygen -q -t rsa -C '' -N '' -f ~rundeck/.ssh/id_rsa" rundeck
 fi
-/sbin/chkconfig --add rundeckd
 
-DIR=/etc/rundeck
+DIR="${ETC_DIR}"
 
+SSL_CONFIG="${DIR}/ssl/"
 RDECK_CONFIG="$DIR/rundeck-config.properties"
 FW_CONFIG="$DIR/framework.properties"
+PROJECT_CONFIG="$DIR/project.properties"
+LOG4J_CONFIG="$DIR/log4j.properties"
+JAAS_CONFIG="$DIR/jaas-loginmodule.conf"
 
 if [ -f "$DIR/rundeck-config.properties.rpmnew" ]; then
     RDECK_CONFIG="$DIR/rundeck-config.properties.rpmnew"
@@ -20,6 +27,20 @@ fi
 if [ -f "$DIR/framework.properties.rpmnew" ]; then
     FW_CONFIG="$DIR/framework.properties.rpmnew"
 fi
+
+if [ -f "$PROJECT_CONFIG.rpmnew" ]; then
+    PROJECT_CONFIG="$PROJECT_CONFIG.rpmnew"
+fi
+
+if [ -f "$LOG4J_CONFIG.rpmnew" ]; then
+    LOG4J_CONFIG="$LOG4J_CONFIG.rpmnew"
+fi
+
+
+if [ -f "$JAAS_CONFIG.rpmnew" ]; then
+    JAAS_CONFIG="$JAAS_CONFIG.rpmnew"
+fi
+
 
 if  ! grep -E '^\s*rundeck.server.uuid\s*=\s*.{8}-.{4}-.{4}-.{4}-.{12}\s*$' "$FW_CONFIG" ; then
     uuid=$(uuidgen)
@@ -33,3 +54,36 @@ fi
 STORAGE_PASS=$(openssl rand -hex 8)
 sed -i -E 's/^rundeck\.storage\.converter\.([0-9]+)\.config\.password=default\.encryption\.password$/rundeck.storage.converter.\1.config.password='"$STORAGE_PASS"'/' "$RDECK_CONFIG"
 sed -i -E 's/^rundeck\.config\.storage\.converter\.([0-9]+)\.config\.password=default\.encryption\.password$/rundeck.config.storage.converter.\1.config.password='"$STORAGE_PASS"'/' "$RDECK_CONFIG"
+
+if [[ "${HOME_DIR}" != "/var/lib/rundeck" ]] ; then
+    sed -i -E "s#/var/lib/rundeck#${HOME_DIR}#g" "${DIR}/profile"
+
+    sed -i -E "s#/var/lib/rundeck#${HOME_DIR}#g" "${FW_CONFIG}"
+    sed -i -E "s#/var/lib/rundeck#${HOME_DIR}#g" "${RDECK_CONFIG}"
+    sed -i -E "s#/var/lib/rundeck#${HOME_DIR}#g" "${PROJECT_CONFIG}"
+fi
+
+if [[ "${ETC_DIR}" != "/etc/rundeck" ]] ; then
+    sed -i -E "s#/etc/rundeck#${ETC_DIR}#g" "${DIR}/profile"
+    sed -i -E "s#/etc/sysconfig#${ETC_DIR}#g" "${DIR}/profile"
+
+    sed -i -E "s#/etc/rundeck#${ETC_DIR}#g" "${FW_CONFIG}"
+    sed -i -E "s#/etc/rundeck#${ETC_DIR}#g" "${RDECK_CONFIG}"
+    sed -i -E "s#/etc/rundeck#${ETC_DIR}#g" "${JAAS_CONFIG}"
+
+    sed -i -E "s#/etc/rundeck#${ETC_DIR}#g" "${INIT_DIR}/rundeckd"
+    sed -i -E "s#/etc/sysconfig#${ETC_DIR}#g" "${INIT_DIR}/rundeckd"
+fi
+
+if [[ "${LOG_DIR}" != "/var/log/rundeck" ]] ; then
+    sed -i -E "s#/var/log/rundeck#${LOG_DIR}#g" "${INIT_DIR}/rundeckd"
+    sed -i -E "s#/var/log/rundeck#${LOG_DIR}#g" "${LOG4J_CONFIG}"
+fi
+
+if [[ "${TMP_DIR}" != "/tmp/rundeck" ]] ; then
+    sed -i -E "s#/tmp/rundeck#${LOG_DIR}#g" "${DIR}/profile"
+fi
+
+if [[ "$INIT_DIR" == "/etc/rc.d/init.d" ]]; then
+    /sbin/chkconfig --add rundeckd
+fi

--- a/lib/rpm/scripts/preinst.sh
+++ b/lib/rpm/scripts/preinst.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
 
+HOME_DIR="${RPM_INSTALL_PREFIX0:-/var/lib/rundeck}"
+
+HOME_DIRNAME=$(dirname "${HOME_DIR}")
+
+# Create the home parent directory in case it does not exist(it was relocated)
+if [[ ! -d "$HOME_DIRNAME" ]] ; then
+    mkdir -p "${HOME_DIRNAME}"
+fi
+
 getent group rundeck >/dev/null || groupadd rundeck
-getent passwd rundeck >/dev/null || useradd -d /var/lib/rundeck -m -g rundeck rundeck
+getent passwd rundeck >/dev/null || useradd -d "${HOME_DIR}" -m -g rundeck rundeck

--- a/lib/rpm/scripts/preuninst.sh
+++ b/lib/rpm/scripts/preuninst.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 
+INIT_DIR="${RPM_INSTALL_PREFIX4:-/etc/rc.d/init.d}"
+
 if [ "$1" = 0 ]; then
-    /sbin/service rundeckd stop
-    /sbin/chkconfig --del rundeckd
+    if [[ "$INIT_DIR" == "/etc/rc.d/init.d" ]]; then
+        /sbin/service rundeckd stop
+        /sbin/chkconfig --del rundeckd
+    fi
 fi

--- a/scripts/sign-packages.sh
+++ b/scripts/sign-packages.sh
@@ -13,6 +13,10 @@ KEYID=${SIGNING_KEYID:-}
 PASSWORD=${SIGNING_PASSWORD:-}
 GPG_PATH=${GPG_PATH:-./ci-resources}
 
+if [[ -z "$PASSWORD" ]] ; then
+    echo -n 'Enter signing key password passphrase:'
+    read -s PASSWORD
+fi
 
 usage() {
       grep '^#/' <"$0" | cut -c4- # prints the #/ lines above as usage info


### PR DESCRIPTION
* Allows RPM install paths to be relocated
* Removes the use of `chown` in rpm `postinst` in favor of setting user/group in generated spec
* Re-introduces the obsoletes for enterprise builds