### PR TITLE
Fixes 3.1.0

### DIFF
--- a/buildSrc/src/main/groovy/org/rundeck/gradle/PackagingTask.groovy
+++ b/buildSrc/src/main/groovy/org/rundeck/gradle/PackagingTask.groovy
@@ -218,7 +218,7 @@ class PackageTask extends DefaultTask {
 
             // Requirements
             requires('openssh-client')
-            requires('java7-runtime').or('java7-runtime-headless').or('java8-runtime').or('java8-runtime-headless')
+            requires('java8-runtime-headless').or('java8-runtime')
             requires('adduser', '3.11', GREATER | EQUAL)
             requires('uuid-runtime')
             requires('openssl')
@@ -269,6 +269,8 @@ class PackageTask extends DefaultTask {
             if (packageName =~ /enterprise/) {
                 obsoletes('rundeckpro-cluster', '3.0.9', Flags.EQUAL | Flags.LESS)
                 postInstall project.file("$libDir/rpm/scripts/postinst-cluster.sh")
+            } else {
+                obsoletes('rundeck-config')
             }
             preUninstall project.file("$libDir/rpm/scripts/preuninst.sh")
             postUninstall project.file("$libDir/rpm/scripts/postuninst.sh")

--- a/lib/deb/scripts/postinst
+++ b/lib/deb/scripts/postinst
@@ -90,8 +90,9 @@ if  ! grep -E '^\s*rundeck.server.uuid\s*=\s*.{8}-.{4}-.{4}-.{4}-.{12}\s*$' $DIR
 fi
 
 #setting a random password for encryption
-STORAGE_PASS=$(openssl rand -hex 8)
-sed -i -E 's/^rundeck\.storage\.converter\.([0-9]+)\.config\.password=default\.encryption\.password$/rundeck.storage.converter.\1.config.password='"$STORAGE_PASS"'/' "$DIR/rundeck-config.properties"
-sed -i -E 's/^rundeck\.config\.storage\.converter\.([0-9]+)\.config\.password=default\.encryption\.password$/rundeck.config.storage.converter.\1.config.password='"$STORAGE_PASS"'/' "$DIR/rundeck-config.properties"
-
+if [ -f "$DIR/rundeck-config.properties" ] ; then
+  STORAGE_PASS=$(openssl rand -hex 8)
+  sed -i -E 's/^rundeck\.storage\.converter\.([0-9]+)\.config\.password=default\.encryption\.password$/rundeck.storage.converter.\1.config.password='"$STORAGE_PASS"'/' "$DIR/rundeck-config.properties"
+  sed -i -E 's/^rundeck\.config\.storage\.converter\.([0-9]+)\.config\.password=default\.encryption\.password$/rundeck.config.storage.converter.\1.config.password='"$STORAGE_PASS"'/' "$DIR/rundeck-config.properties"
+fi
 


### PR DESCRIPTION
Fixes some upgrade issues people were having with `3.1.0`:

* RPM obsoletes the config package now so it can takeover the files without having to manually back/restore and remove the package
* DEB postinst checks for `rundeck-config.properties` in case it was removed by the user

In addition the requirement is now for JDK 8 and favors the headless package.