### PR TITLE
Make the service.log path customizable

### DIFF
--- a/lib/deb/etc/init.d/rundeckd
+++ b/lib/deb/etc/init.d/rundeckd
@@ -28,7 +28,7 @@ RETVAL=0
 PIDFILE=/var/run/$prog.pid
 DAEMON="${JAVA_HOME:-/usr}/bin/java"
 DAEMON_EXEC="$rundeckd"
-LOG="/var/log/rundeck/service.log"
+LOG="${RUNDECK_LOGDIR/service.log:-/var/log/rundeck/service.log}"
 
 
 start() {


### PR DESCRIPTION
This PR make the location of the /var/log/rundeck/service.log customizable when using the init.d script.