### PR TITLE
RUN-2568: Increase expect timeout

### DIFF
--- a/scripts/signing-helpers.sh
+++ b/scripts/signing-helpers.sh
@@ -193,7 +193,7 @@ sign_debs_gpg2(){
         GPG_TTY=$(tty)
         export GPG_TTY
     fi
-
+    time \
     expect - -- $KEYID $PASSWORD  <<END
 spawn dpkg-sig --gpg-options "-u [lindex \$argv 0] --pinentry-mode loopback" --sign builder $DEB
 set timeout 60

--- a/scripts/signing-helpers.sh
+++ b/scripts/signing-helpers.sh
@@ -78,6 +78,7 @@ sign_rpms(){
 
     expect - -- $GPG_PATH $KEYID $PASSWORD  <<END
 spawn rpm --define "_gpg_name [lindex \$argv 1]" --define "_gpg_path [lindex \$argv 0]" --define "__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --digest-algo sha256 --batch --no-verbose --passphrase-fd 3 --no-secmem-warning -u \"%{_gpg_name}\" -sbo %{__signature_filename} %{__plaintext_filename}" --addsign $RPM
+set timeout 60
 expect {
     -re "Enter pass *phrase: *" { log_user 0; send -- "[lindex \$argv 2]\r"; log_user 1; }
     eof { catch wait rc; exit [lindex \$rc 3]; }
@@ -118,6 +119,7 @@ sign_rpms_gpg2(){
     #export GNUPGHOME=$GPG_PATH
     expect - -- $GPG_PATH $KEYID $PASSWORD  <<END
 spawn rpm --define "_gpg_name [lindex \$argv 1]" --define "_gpg_path [lindex \$argv 0]" --define "__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --digest-algo sha256 --no-verbose --pinentry-mode loopback --no-secmem-warning -u \"%{_gpg_name}\" -sbo %{__signature_filename} %{__plaintext_filename}" --addsign $RPM
+set timeout 60
 expect {
     -re "Enter pass *phrase: *" { log_user 0; send -- "[lindex \$argv 2]\r"; log_user 1; }
     eof { catch wait rc; exit [lindex \$rc 3]; }
@@ -194,6 +196,7 @@ sign_debs_gpg2(){
 
     expect - -- $KEYID $PASSWORD  <<END
 spawn dpkg-sig --gpg-options "-u [lindex \$argv 0] --pinentry-mode loopback" --sign builder $DEB
+set timeout 60
 expect {
     # Passphrase prompt arrives for each deb signed; exp_continue allows this block to execute multiple times
     "Enter passphrase:" { log_user 0; send -- "[lindex \$argv 1]\r"; log_user 1; exp_continue }

--- a/scripts/signing-helpers.sh
+++ b/scripts/signing-helpers.sh
@@ -193,7 +193,7 @@ sign_debs_gpg2(){
         GPG_TTY=$(tty)
         export GPG_TTY
     fi
-    time \
+
     expect - -- $KEYID $PASSWORD  <<END
 spawn dpkg-sig --gpg-options "-u [lindex \$argv 0] --pinentry-mode loopback" --sign builder $DEB
 set timeout 60


### PR DESCRIPTION
some expect scripts use default timeout (10 seconds) which may be contributing to some failures in CI