### PR TITLE
RUN-2343: Add java 17 support

### DIFF
--- a/buildSrc/src/main/groovy/org/rundeck/gradle/PackagingTask.groovy
+++ b/buildSrc/src/main/groovy/org/rundeck/gradle/PackagingTask.groovy
@@ -166,6 +166,8 @@ class PackageTask extends DefaultTask {
             requires('openssh-client')
             requires('java11-runtime-headless')
                     .or('java11-runtime')
+                    .or('java17-runtime-headless')
+                    .or('java17-runtime')
             requires('adduser', '3.11', GREATER | EQUAL)
             requires('uuid-runtime')
             requires('openssl')
@@ -214,14 +216,19 @@ class PackageTask extends DefaultTask {
 
             applySharedConfig(it)
 
+            // Requirements
             requires('chkconfig')
             requires('initscripts')
-            requires("openssh")
+            requires('openssh')
             requires('openssl')
             requires('java-11-headless')
                     .or('jre-11-headless')
                     .or('java-11')
                     .or('jre-11')
+                    .or('java-17-headless')
+                    .or('jre-17-headless')
+                    .or('java-17')
+                    .or('jre-17')
 
             // Install scripts
             preInstall project.file("$libDir/rpm/scripts/preinst.sh")

--- a/buildSrc/src/main/groovy/org/rundeck/gradle/PackagingTask.groovy
+++ b/buildSrc/src/main/groovy/org/rundeck/gradle/PackagingTask.groovy
@@ -221,14 +221,6 @@ class PackageTask extends DefaultTask {
             requires('initscripts')
             requires('openssh')
             requires('openssl')
-            requires('java-11-headless')
-                    .or('jre-11-headless')
-                    .or('java-11')
-                    .or('jre-11')
-                    .or('java-17-headless')
-                    .or('jre-17-headless')
-                    .or('java-17')
-                    .or('jre-17')
 
             // Install scripts
             preInstall project.file("$libDir/rpm/scripts/preinst.sh")


### PR DESCRIPTION
Rundeck now support Java 17, but still wants to install java 11.

This fixes https://github.com/rundeck/rundeck/issues/8917#issuecomment-2743354000