### PR TITLE
RUN-3243 Rundeck RPM package still requiring Java 11 even if Java 17 is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ Consolidated deb and rpm packaging and signing.
 
 ### Package
 
-> NOTE: Place the built Rundeck war files in `./artifacts` . The build
-parses version information out of the file names, so the names matter!
+> NOTE: Create a directory named `artifacts` in the root directory and place the built Rundeck WAR files there.  
+> The build parses version information out of the file names, so the names matter!
 
+> NOTE: `-PlibsDir` should point to the `Rundeck oss packaging/lib` directory.
 ```
 ./gradlew \
             -PpackageRelease=$RELEASE_NUM \
+            -PlibsDir=../lib \
             clean packageArtifacts
 ```
 

--- a/buildSrc/src/main/groovy/org/rundeck/gradle/PackagingTask.groovy
+++ b/buildSrc/src/main/groovy/org/rundeck/gradle/PackagingTask.groovy
@@ -166,6 +166,8 @@ class PackageTask extends DefaultTask {
             requires('openssh-client')
             requires('java11-runtime-headless')
                     .or('java11-runtime')
+                    .or('java17-runtime-headless')
+                    .or('java17-runtime')
             requires('adduser', '3.11', GREATER | EQUAL)
             requires('uuid-runtime')
             requires('openssl')
@@ -214,14 +216,19 @@ class PackageTask extends DefaultTask {
 
             applySharedConfig(it)
 
+            // Requirements
             requires('chkconfig')
             requires('initscripts')
-            requires("openssh")
+            requires('openssh')
             requires('openssl')
             requires('java-11-headless')
                     .or('jre-11-headless')
                     .or('java-11')
                     .or('jre-11')
+                    .or('java-17-headless')
+                    .or('jre-17-headless')
+                    .or('java-17')
+                    .or('jre-17')
 
             // Install scripts
             preInstall project.file("$libDir/rpm/scripts/preinst.sh")

--- a/buildSrc/src/main/groovy/org/rundeck/gradle/PackagingTask.groovy
+++ b/buildSrc/src/main/groovy/org/rundeck/gradle/PackagingTask.groovy
@@ -221,14 +221,6 @@ class PackageTask extends DefaultTask {
             requires('initscripts')
             requires('openssh')
             requires('openssl')
-            requires('java-11-headless')
-                    .or('jre-11-headless')
-                    .or('java-11')
-                    .or('jre-11')
-                    .or('java-17-headless')
-                    .or('jre-17-headless')
-                    .or('java-17')
-                    .or('jre-17')
 
             // Install scripts
             preInstall project.file("$libDir/rpm/scripts/preinst.sh")


### PR DESCRIPTION
remove java11 dependency from PackageTask for .rpm packaging and move it to the preinst.sh 

Related to https://github.com/rundeck/rundeck/pull/9624