### PR TITLE
[RUN-4388] Update Bouncy Castle to 1.84 for additional security fixes

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 // Mitigate CVE-2024-25710: Force commons-compress to 1.26.2
 // SNYK-JAVA-ORGAPACHECOMMONS-10734078 (CVE-2025-48924): commons-lang3 requires 3.18.0+
-// Mitigate CVE-2025-8916: Force Bouncy Castle dependencies to 1.79
+// Mitigate CVE-2025-8916 and additional CVEs: Force Bouncy Castle dependencies to 1.84
 configurations.all {
     resolutionStrategy {
         force "org.apache.commons:commons-compress:${commonsCompressVersion}"

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,3 +1,3 @@
 commonsCompressVersion=1.26.2
 commonsLang3Version=3.20.0
-bouncyCastleVersion=1.79
+bouncyCastleVersion=1.84

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 commonsCompressVersion=1.26.2
 commonsLang3Version=3.20.0
-bouncyCastleVersion=1.79
+bouncyCastleVersion=1.84


### PR DESCRIPTION
## Summary
- Updates Bouncy Castle dependency from version 1.79 to 1.84
- Addresses multiple CVEs beyond the original CVE-2025-8916
- Only affects build-time RPM package signing (no runtime impact)

## Security Fixes
This update includes fixes for:
- **CVE-2025-8916** - Already fixed in 1.79, maintained in 1.84
- **CVE-2026-0636** - LDAP Injection vulnerability
- **CVE-2026-3505** - PGP AEAD resource exhaustion
- **CVE-2026-5588** - PKIX signature validation issue
- **CVE-2026-5598** - FrodoKEM private key leakage

## Impact
- Bouncy Castle is used exclusively for PGP signing of RPM packages during build
- Does not affect Rundeck application runtime or secret encryption
- The encryption issues encountered in the core Rundeck repo do not apply here

## Test Plan
- [ ] Build packages with the updated dependency
- [ ] Verify RPM signatures are valid
- [ ] Confirm no build failures